### PR TITLE
Optimise generate-video-preview.js

### DIFF
--- a/src/lib/generate-video-preview.js
+++ b/src/lib/generate-video-preview.js
@@ -73,7 +73,8 @@ export default async (filePath, start, end, key, size = "m", mute = false) => {
               command = new GetObjectCommand(params);
               signedUrl = await getSignedUrl(s3, command, { expiresIn: 60 * 5 });
               const tsResponse = await fetch(signedUrl);
-              fs.writeFileSync(path.join(tempPath, ts), tsResponse);
+              const tsArrayBuffer = await tsResponse.arrayBuffer();
+              fs.writeFileSync(path.join(tempPath, ts), Buffer.from(tsArrayBuffer));
             } catch (error) {
               console.log(error);
             }

--- a/src/lib/generate-video-preview.js
+++ b/src/lib/generate-video-preview.js
@@ -152,6 +152,6 @@ export default async (filePath, start, end, key, size = "m", mute = false) => {
   if (ffmpeg.stderr.length) {
     console.log(ffmpeg.stderr.toString());
   }
-  fs.rmdirSync(tempPath, { recursive: true, force: true });
+  fs.rmSync(tempPath, { recursive: true, force: true });
   return ffmpeg.stdout;
 };


### PR DESCRIPTION
Problem context: 

> The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Response

![loading](https://github.com/shotit/shotit-media/assets/27696701/de47c505-541c-4f04-b270-9acaa605c2dc)

To resolve: 

> use arrayBuffer & Buffer to save HLS-TS files

In addition: 

> turn to use fs.rmdir to respond to the warning `DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`
