### PR TITLE
Feat: add duration to image.js to boost

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/src/image.js
+++ b/src/image.js
@@ -3,6 +3,8 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import crypto from "crypto";
 import child_process from "child_process";
 
+import detectScene from "./lib/detect-scene.js";
+
 const {
   AWS_ENDPOINT_URL,
   AWS_ACCESS_KEY,
@@ -110,9 +112,14 @@ export default async (req, res) => {
   try {
     command = new GetObjectCommand(params);
     const signedUrl = await getSignedUrl(s3, command, { expiresIn: 60 * 5 });
-
+    const scene = await detectScene(signedUrl, t, minDuration > 2 ? 2 : minDuration);
+    if (scene === null) {
+      return res.status(503).send("Service Unavailable");
+    }
     const image = generateImagePreview(signedUrl, t, size);
     res.set("Content-Type", "image/jpg");
+    res.set("x-video-duration", scene.duration);
+    res.set("Access-Control-Expose-Headers", "x-video-duration");
     res.send(image);
   } catch (e) {
     console.log(e);

--- a/src/image.js
+++ b/src/image.js
@@ -109,6 +109,7 @@ export default async (req, res) => {
   if (!["l", "m", "s"].includes(size)) {
     return res.status(400).send("Bad Request. Invalid param: size");
   }
+  const minDuration = Number(req.query.minDuration) || 0.25;
   try {
     command = new GetObjectCommand(params);
     const signedUrl = await getSignedUrl(s3, command, { expiresIn: 60 * 5 });

--- a/src/image.test.js
+++ b/src/image.test.js
@@ -29,6 +29,7 @@ test(
     );
     expect(response.statusCode).toBe(200);
     expect(response.headers["content-type"]).toMatch(/^image\/jpg/);
+    expect(response.headers["x-video-duration"]).toBe("596.500001");
   },
   60 * 1000
 );


### PR DESCRIPTION
Elaborate:

Currently the shotit system is not providing the video duration information as quick as possible. The duration information is provided by video.js. User search -> api response containing video clip link -> fetch video clip link -> get duration from header x-video-duration. Due to the necessary workload to process video, the response time is a bit slow. A better practice is to move the functionality of x-video-duration to image.js, which is much more quick.